### PR TITLE
Issue 14: Basic HTTP Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Configuration Parameter | Default | Description
 **include.message.headers** | true | Indicates whether message headers from source records should be preserved after the transform.
 **schema.capacity** | 100 | Capacity of schemas that can be cached in each `CachedSchemaRegistryClient`
 
+## Embedded Schema Registry Client Configuration
+
+Schema Registry Transfer SMT passes some properties prefixed by either `src.` or `dest.`
+through to its embedded schema registry clients, after stripping away `src.` or `dest.`
+prefix used to disambiguate which client is to receive which configuration value.
+
+Properties prefixed by `src.` are passed through to the source consumer's schema registry
+client.  Properties prefixed by `dest.` are passed through to the target producer's schema
+registry client.
+
+Configuration Parameter | Default | Description
+----------------------- | ------- | -----------
+**(src|dest).basic.auth.credentials.source** | URL | Specify how to pick credentials for Basic Auth header. Supported values are URL, USER_INFO and SASL_INHERIT
+**(src|dest).basic.auth.user.info** |  | Specify credentials for Basic Auth in form of {username}:{password} when source is USER_INFO
 
 ## Subject Renaming
 

--- a/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
+++ b/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
@@ -41,8 +41,21 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
     public static final ConfigDef CONFIG_DEF;
     public static final String SCHEMA_CAPACITY_CONFIG_DOC = "The maximum amount of schemas to be stored for each Schema Registry client.";
     public static final Integer SCHEMA_CAPACITY_CONFIG_DEFAULT = 100;
+
+    public static final String SRC_PREAMBLE = "For source consumer's schema registry, ";
     public static final String SRC_SCHEMA_REGISTRY_CONFIG_DOC = "A list of addresses for the Schema Registry to copy from. The consumer's Schema Registry.";
+    public static final String SRC_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DOC = SRC_PREAMBLE + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DOC;
+    public static final String SRC_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DEFAULT = AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT;
+    public static final String SRC_USER_INFO_CONFIG_DOC = SRC_PREAMBLE + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DOC;
+    public static final String SRC_USER_INFO_CONFIG_DEFAULT = AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DEFAULT;
+
+    public static final String DEST_PREAMBLE = "For target producer's schema registry, ";
     public static final String DEST_SCHEMA_REGISTRY_CONFIG_DOC = "A list of addresses for the Schema Registry to copy to. The producer's Schema Registry.";
+    public static final String DEST_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DOC = DEST_PREAMBLE + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DOC;
+    public static final String DEST_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DEFAULT = AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT;
+    public static final String DEST_USER_INFO_CONFIG_DOC = DEST_PREAMBLE + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DOC;
+    public static final String DEST_USER_INFO_CONFIG_DEFAULT = AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DEFAULT;
+
     public static final String TRANSFER_KEYS_CONFIG_DOC = "Whether or not to copy message key schemas between registries.";
     public static final Boolean TRANSFER_KEYS_CONFIG_DEFAULT = true;
     public static final String INCLUDE_HEADERS_CONFIG_DOC = "Whether or not to preserve the Kafka Connect Record headers.";
@@ -63,10 +76,10 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
         CONFIG_DEF = (new ConfigDef())
                 .define(ConfigName.SRC_SCHEMA_REGISTRY_URL, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(), ConfigDef.Importance.HIGH, SRC_SCHEMA_REGISTRY_CONFIG_DOC)
                 .define(ConfigName.DEST_SCHEMA_REGISTRY_URL, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(), ConfigDef.Importance.HIGH, DEST_SCHEMA_REGISTRY_CONFIG_DOC)
-                .define(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT, ConfigDef.Importance.MEDIUM, "For source consumer's schema registry, " + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
-                .define(ConfigName.SRC_USER_INFO, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DEFAULT, ConfigDef.Importance.MEDIUM, "For source consumer's schema registry, " + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DOC)
-                .define(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT, ConfigDef.Importance.MEDIUM, "For target producer's schema registry, " + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
-                .define(ConfigName.DEST_USER_INFO, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DEFAULT, ConfigDef.Importance.MEDIUM, "For target producer's schema registry, " + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DOC)
+                .define(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, SRC_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, SRC_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DOC)
+                .define(ConfigName.SRC_USER_INFO, ConfigDef.Type.STRING, SRC_USER_INFO_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, SRC_USER_INFO_CONFIG_DOC)
+                .define(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, DEST_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, DEST_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DOC)
+                .define(ConfigName.DEST_USER_INFO, ConfigDef.Type.STRING, DEST_USER_INFO_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, DEST_USER_INFO_CONFIG_DOC)
                 .define(ConfigName.SCHEMA_CAPACITY, ConfigDef.Type.INT, SCHEMA_CAPACITY_CONFIG_DEFAULT, ConfigDef.Importance.LOW, SCHEMA_CAPACITY_CONFIG_DOC)
                 .define(ConfigName.TRANSFER_KEYS, ConfigDef.Type.BOOLEAN, TRANSFER_KEYS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, TRANSFER_KEYS_CONFIG_DOC)
                 .define(ConfigName.INCLUDE_HEADERS, ConfigDef.Type.BOOLEAN, INCLUDE_HEADERS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, INCLUDE_HEADERS_CONFIG_DOC)

--- a/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
+++ b/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
@@ -3,6 +3,7 @@ package cricket.jmoore.kafka.connect.transforms;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,6 +63,10 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
         CONFIG_DEF = (new ConfigDef())
                 .define(ConfigName.SRC_SCHEMA_REGISTRY_URL, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(), ConfigDef.Importance.HIGH, SRC_SCHEMA_REGISTRY_CONFIG_DOC)
                 .define(ConfigName.DEST_SCHEMA_REGISTRY_URL, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(), ConfigDef.Importance.HIGH, DEST_SCHEMA_REGISTRY_CONFIG_DOC)
+                .define(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT, ConfigDef.Importance.MEDIUM, "For source consumer's schema registry, " + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
+                .define(ConfigName.SRC_USER_INFO, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DEFAULT, ConfigDef.Importance.MEDIUM, "For source consumer's schema registry, " + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DOC)
+                .define(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT, ConfigDef.Importance.MEDIUM, "For target producer's schema registry, " + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
+                .define(ConfigName.DEST_USER_INFO, ConfigDef.Type.STRING, AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DEFAULT, ConfigDef.Importance.MEDIUM, "For target producer's schema registry, " + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_USER_INFO_DOC)
                 .define(ConfigName.SCHEMA_CAPACITY, ConfigDef.Type.INT, SCHEMA_CAPACITY_CONFIG_DEFAULT, ConfigDef.Importance.LOW, SCHEMA_CAPACITY_CONFIG_DOC)
                 .define(ConfigName.TRANSFER_KEYS, ConfigDef.Type.BOOLEAN, TRANSFER_KEYS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, TRANSFER_KEYS_CONFIG_DOC)
                 .define(ConfigName.INCLUDE_HEADERS, ConfigDef.Type.BOOLEAN, INCLUDE_HEADERS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, INCLUDE_HEADERS_CONFIG_DOC)
@@ -79,12 +84,24 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
         SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
 
         List<String> sourceUrls = config.getList(ConfigName.SRC_SCHEMA_REGISTRY_URL);
+        final Map<String, String> sourceProps = new HashMap<>();
+        sourceProps.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
+            config.getString(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE));
+        sourceProps.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG,
+            config.getString(ConfigName.SRC_USER_INFO));
+
         List<String> destUrls = config.getList(ConfigName.DEST_SCHEMA_REGISTRY_URL);
+        final Map<String, String> destProps = new HashMap<>();
+        destProps.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
+            config.getString(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE));
+        destProps.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG,
+            config.getString(ConfigName.DEST_USER_INFO));
+
         Integer schemaCapacity = config.getInt(ConfigName.SCHEMA_CAPACITY);
 
         this.schemaCache = new SynchronizedCache<>(new LRUCache<>(schemaCapacity));
-        this.sourceSchemaRegistryClient = new CachedSchemaRegistryClient(sourceUrls, schemaCapacity);
-        this.destSchemaRegistryClient = new CachedSchemaRegistryClient(destUrls, schemaCapacity);
+        this.sourceSchemaRegistryClient = new CachedSchemaRegistryClient(sourceUrls, schemaCapacity, sourceProps);
+        this.destSchemaRegistryClient = new CachedSchemaRegistryClient(destUrls, schemaCapacity, destProps);
 
         this.transferKeys = config.getBoolean(ConfigName.TRANSFER_KEYS);
         this.includeHeaders = config.getBoolean(ConfigName.INCLUDE_HEADERS);
@@ -213,7 +230,11 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
 
     interface ConfigName {
         String SRC_SCHEMA_REGISTRY_URL = "src." + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+        String SRC_BASIC_AUTH_CREDENTIALS_SOURCE = "src." + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE;
+        String SRC_USER_INFO = "src." + AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG;
         String DEST_SCHEMA_REGISTRY_URL = "dest." + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+        String DEST_BASIC_AUTH_CREDENTIALS_SOURCE = "dest." + AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE;
+        String DEST_USER_INFO = "dest." + AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG;
         String SCHEMA_CAPACITY = "schema.capacity";
         String TRANSFER_KEYS = "transfer.message.keys";
         String INCLUDE_HEADERS = "include.message.headers";

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
@@ -1,3 +1,4 @@
+/* Licensed under Apache-2.0 */
 package cricket.jmoore.kafka.connect.transforms;
 
 public interface Constants {

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
@@ -1,0 +1,15 @@
+package cricket.jmoore.kafka.connect.transforms;
+
+public interface Constants {
+    public static final String USE_BASIC_AUTH_SOURCE_TAG = "useBasicAuthSource";
+
+    public static final String USE_BASIC_AUTH_DEST_TAG = "useBasicAuthDest";
+
+    public static final String USER_INFO_SOURCE = "USER_INFO";
+
+    public static final String URL_SOURCE = "URL";
+
+    public static final String HTTP_AUTH_CREDENTIALS_FIXTURE = "username:password";
+
+    public static final String HELLO_WORLD_VALUE = "Hello, world!";
+}

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
@@ -10,6 +10,4 @@ public interface Constants {
     public static final String URL_SOURCE = "URL";
 
     public static final String HTTP_AUTH_CREDENTIALS_FIXTURE = "username:password";
-
-    public static final String HELLO_WORLD_VALUE = "Hello, world!";
 }

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryMock.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryMock.java
@@ -119,7 +119,7 @@ public class SchemaRegistryMock implements BeforeEachCallback, AfterEachCallback
 
     public SchemaRegistryMock(Role role) {
         if (role == null) {
-            throw new NullPointerException("Role must be either SOURCE or DESTINATION");
+            throw new IllegalArgumentException("Role must be either SOURCE or DESTINATION");
         }
 
         this.basicAuthTag = (role == Role.SOURCE) ? Constants.USE_BASIC_AUTH_SOURCE_TAG : Constants.USE_BASIC_AUTH_DEST_TAG; 

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/TransformTest.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/TransformTest.java
@@ -53,6 +53,8 @@ public class TransformTest {
 
     private static final Logger log = LoggerFactory.getLogger(TransformTest.class);
 
+    public static final String HELLO_WORLD_VALUE = "Hello, world!";
+
     public static final String TOPIC = TransformTest.class.getSimpleName();
 
     private static final byte MAGIC_BYTE = (byte) 0x0;
@@ -187,9 +189,9 @@ public class TransformTest {
         final int sourceValId = sourceSchemaRegistry.registerSchema(TOPIC, false, STRING_SCHEMA);
 
         final ByteArrayOutputStream keyOut =
-            encodeAvroObject(STRING_SCHEMA, sourceKeyId, Constants.HELLO_WORLD_VALUE);
+            encodeAvroObject(STRING_SCHEMA, sourceKeyId, HELLO_WORLD_VALUE);
         final ByteArrayOutputStream valOut =
-            encodeAvroObject(STRING_SCHEMA, sourceValId, Constants.HELLO_WORLD_VALUE);
+            encodeAvroObject(STRING_SCHEMA, sourceValId, HELLO_WORLD_VALUE);
         final ConnectRecord record =
             createRecord(keyOut.toByteArray(), valOut.toByteArray());
 


### PR DESCRIPTION
schema-registry-transfer-smt is not propagating any properties from its
own input configuration to a properties hash on either the source or
target embedded schema registry clients. There is no way to set
basic.auth.credentials.source to USER_INFO and provide a
basic.auth.user.info property that carries the credentials.

Curiously, the default behavior for basic.auth.credentials.source is
URL, which supports passing credentials in the schema registry URL value
itself, which normally has a form like http(s)://<host>:<port>/, by
inserting them before the host:port combination followed by an @, like
this: http(s)://<username>:<password>@<host>:<port>/. Unfortunately,
this default behavior only seems to apply if the schema registry client
is given a properties map--it does not seem to work when the third
constructor argument for that hash is not even used.

Accept a pair of the two required properties prefixed by either src. or
dest..  Then, strip the prefix away while routing the remaining property
name and its value to a config HashMap for the appropriate embedded
client.

For example, the following four properties might be used to configure
access credentials for both clients appropriately:

{ ..., "src.basic.auth.credentials.source": "USER_INFO",
"src.basic.auth.user.info": "srcuser:srcpassword",
"dest.basic.auth.credentials.source": "USER_INFO",
"dest.basic.auth.user.info": "destuser:destpassword", ... }

Test cases are included that use a JUnit @Tag mechanism to inform the
SchemaRegistryMock class when to enforce an expectation of HTTP Basic
Authentication credentials, which are then used to assert the correct
behavior when the authentication.source key is set to USER_INFO, URL, or
null.  The default behavior of URL when no key is inserted at all is
also verified.