### PR TITLE
Issue16 fix http auth relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,9 @@
                             <shadedPattern>${shade.prefix}.avroshaded</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Tolerates relocation of the Basic HTTP Auth service providers by enabling Shade plugin features that address the fact that Schema Registry uses Java's Service Provider interface to locate and create an instance of a strategy interface matching the credential source type named through `basic.auth.credentials.source`.
