### PR TITLE
Fix relocation for Basic HTTP Auth Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,9 @@
                             <shadedPattern>${shade.prefix}.avroshaded</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Tune the shade plugin's relocation of Confluent's Schema Registry Client to account for its Basic HTTP Auth support's reliance on Java's Service Provider API.   Modify the shade plugin configuration to enable a transformation feature that address relocated Service Providers.

Without this, the registry client is unable to locate the correct strategy implementation corresponding to any of the three supported values for `basic.auth.credentials.source`.
