### PR TITLE
Cure HTTP Authentication Singleton's Password Overwrite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,9 @@
                             <shadedPattern>${shade.prefix}.avroshaded</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
+++ b/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
@@ -99,14 +99,14 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
         List<String> sourceUrls = config.getList(ConfigName.SRC_SCHEMA_REGISTRY_URL);
         final Map<String, String> sourceProps = new HashMap<>();
         sourceProps.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
-            config.getString(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE));
+            "SRC_" + config.getString(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE));
         sourceProps.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG,
             config.getString(ConfigName.SRC_USER_INFO));
 
         List<String> destUrls = config.getList(ConfigName.DEST_SCHEMA_REGISTRY_URL);
         final Map<String, String> destProps = new HashMap<>();
         destProps.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
-            config.getString(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE));
+            "DEST_" + config.getString(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE));
         destProps.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG,
             config.getString(ConfigName.DEST_USER_INFO));
 

--- a/src/main/java/cricket/jmoore/security/basicauth/DestSaslBasicAuthCredentialProvider.java
+++ b/src/main/java/cricket/jmoore/security/basicauth/DestSaslBasicAuthCredentialProvider.java
@@ -1,0 +1,11 @@
+/* Licensed under Apache-2.0 */
+package cricket.jmoore.security.basicauth;
+
+import io.confluent.kafka.schemaregistry.client.security.basicauth.SaslBasicAuthCredentialProvider;
+
+public class DestSaslBasicAuthCredentialProvider extends SaslBasicAuthCredentialProvider {
+    @Override
+    public String alias() {
+        return "DEST_SASL_INHERIT";
+    }
+}

--- a/src/main/java/cricket/jmoore/security/basicauth/DestUrlBasicAuthCredentialProvider.java
+++ b/src/main/java/cricket/jmoore/security/basicauth/DestUrlBasicAuthCredentialProvider.java
@@ -1,0 +1,11 @@
+/* Licensed under Apache-2.0 */
+package cricket.jmoore.security.basicauth;
+
+import io.confluent.kafka.schemaregistry.client.security.basicauth.UrlBasicAuthCredentialProvider;
+
+public class DestUrlBasicAuthCredentialProvider extends UrlBasicAuthCredentialProvider {
+    @Override
+    public String alias() {
+        return "DEST_URL";
+    }
+}

--- a/src/main/java/cricket/jmoore/security/basicauth/DestUserInfoCredentialProvider.java
+++ b/src/main/java/cricket/jmoore/security/basicauth/DestUserInfoCredentialProvider.java
@@ -1,0 +1,12 @@
+/* Licensed under Apache-2.0 */
+package cricket.jmoore.security.basicauth;
+
+import io.confluent.kafka.schemaregistry.client.security.basicauth.UserInfoCredentialProvider;
+
+public class DestUserInfoCredentialProvider extends UserInfoCredentialProvider
+{
+    @Override
+    public String alias() {
+        return "DEST_USER_INFO";
+    }
+}

--- a/src/main/java/cricket/jmoore/security/basicauth/SrcSaslBasicAuthCredentialProvider.java
+++ b/src/main/java/cricket/jmoore/security/basicauth/SrcSaslBasicAuthCredentialProvider.java
@@ -1,0 +1,11 @@
+/* Licensed under Apache-2.0 */
+package cricket.jmoore.security.basicauth;
+
+import io.confluent.kafka.schemaregistry.client.security.basicauth.SaslBasicAuthCredentialProvider;
+
+public class SrcSaslBasicAuthCredentialProvider extends SaslBasicAuthCredentialProvider {
+    @Override
+    public String alias() {
+        return "SRC_SASL_INHERIT";
+    }
+}

--- a/src/main/java/cricket/jmoore/security/basicauth/SrcUrlBasicAuthCredentialProvider.java
+++ b/src/main/java/cricket/jmoore/security/basicauth/SrcUrlBasicAuthCredentialProvider.java
@@ -1,0 +1,11 @@
+/* Licensed under Apache-2.0 */
+package cricket.jmoore.security.basicauth;
+
+import io.confluent.kafka.schemaregistry.client.security.basicauth.UrlBasicAuthCredentialProvider;
+
+public class SrcUrlBasicAuthCredentialProvider extends UrlBasicAuthCredentialProvider {
+    @Override
+    public String alias() {
+        return "SRC_URL";
+    }
+}

--- a/src/main/java/cricket/jmoore/security/basicauth/SrcUserInfoCredentialProvider.java
+++ b/src/main/java/cricket/jmoore/security/basicauth/SrcUserInfoCredentialProvider.java
@@ -1,0 +1,12 @@
+/* Licensed under Apache-2.0 */
+package cricket.jmoore.security.basicauth;
+
+import io.confluent.kafka.schemaregistry.client.security.basicauth.UserInfoCredentialProvider;
+
+public class SrcUserInfoCredentialProvider extends UserInfoCredentialProvider
+{
+    @Override
+    public String alias() {
+        return "SRC_USER_INFO";
+    }
+}

--- a/src/main/resources/META-INF/services/io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider
+++ b/src/main/resources/META-INF/services/io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider
@@ -1,0 +1,6 @@
+cricket.jmoore.security.basicauth.DestSaslBasicAuthCredentialProvider
+cricket.jmoore.security.basicauth.DestUrlBasicAuthCredentialProvider
+cricket.jmoore.security.basicauth.DestUserInfoCredentialProvider
+cricket.jmoore.security.basicauth.SrcSaslBasicAuthCredentialProvider
+cricket.jmoore.security.basicauth.SrcUrlBasicAuthCredentialProvider
+cricket.jmoore.security.basicauth.SrcUserInfoCredentialProvider

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/Constants.java
@@ -10,5 +10,7 @@ public interface Constants {
 
     public static final String URL_SOURCE = "URL";
 
-    public static final String HTTP_AUTH_CREDENTIALS_FIXTURE = "username:password";
+    public static final String HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE = "sourceuser:sourcepass";
+
+    public static final String HTTP_AUTH_DEST_CREDENTIALS_FIXTURE = "destuser:destpass";
 }

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryMock.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryMock.java
@@ -113,6 +113,7 @@ public class SchemaRegistryMock implements BeforeEachCallback, AfterEachCallback
                     this.getConfigHandler));
     private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     private final String basicAuthTag;
+    private final String basicAuthCredentials;
     private Function<MappingBuilder, StubMapping> stubFor;
 
     private static final Logger log = LoggerFactory.getLogger(SchemaRegistryMock.class);
@@ -123,6 +124,8 @@ public class SchemaRegistryMock implements BeforeEachCallback, AfterEachCallback
         }
 
         this.basicAuthTag = (role == Role.SOURCE) ? Constants.USE_BASIC_AUTH_SOURCE_TAG : Constants.USE_BASIC_AUTH_DEST_TAG; 
+        this.basicAuthCredentials =
+            (role == Role.SOURCE)? Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE : Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE;
     }
 
     @Override
@@ -133,7 +136,7 @@ public class SchemaRegistryMock implements BeforeEachCallback, AfterEachCallback
     @Override
     public void beforeEach(final ExtensionContext context) {
         if (context.getTags().contains(this.basicAuthTag)) {
-            String[] userPass = Constants.HTTP_AUTH_CREDENTIALS_FIXTURE.split(":");
+            final String[] userPass = this.basicAuthCredentials.split(":");
             this.stubFor = (MappingBuilder mappingBuilder) -> this.mockSchemaRegistry.stubFor(
                     mappingBuilder.withBasicAuth(userPass[0], userPass[1]));
         } else {

--- a/src/test/java/cricket/jmoore/kafka/connect/transforms/TransformTest.java
+++ b/src/test/java/cricket/jmoore/kafka/connect/transforms/TransformTest.java
@@ -272,8 +272,21 @@ public class TransformTest {
 
     @Test
     @Tag(Constants.USE_BASIC_AUTH_SOURCE_TAG)
+    @Tag(Constants.USE_BASIC_AUTH_DEST_TAG)
+    public void testBothBasicHttpAuthUserInfo() throws IOException {
+        configure(
+                Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE,
+                Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE,
+                ExplicitAuthType.USER_INFO);
+
+        this.passSimpleMessage();
+    }
+
+
+    @Test
+    @Tag(Constants.USE_BASIC_AUTH_SOURCE_TAG)
     public void testSourceBasicHttpAuthUserInfo() throws IOException {
-        configure(Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, null, ExplicitAuthType.USER_INFO);
+        configure(Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE, null, ExplicitAuthType.USER_INFO);
 
         this.passSimpleMessage();
     }
@@ -281,7 +294,7 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_DEST_TAG)
     public void testDestinationBasicHttpAuthUserInfo() throws IOException {
-        configure(null, Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, ExplicitAuthType.USER_INFO);
+        configure(null, Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE, ExplicitAuthType.USER_INFO);
 
         this.passSimpleMessage();
     }
@@ -289,7 +302,7 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_SOURCE_TAG)
     public void testSourceBasicHttpAuthUrl() throws IOException {
-        configure(Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, null, ExplicitAuthType.URL);
+        configure(Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE, null, ExplicitAuthType.URL);
 
         this.passSimpleMessage();
     }
@@ -297,7 +310,7 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_DEST_TAG)
     public void testDestinationBasicHttpAuthUrl() throws IOException {
-        configure(null, Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, ExplicitAuthType.URL);
+        configure(null, Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE, ExplicitAuthType.URL);
 
         this.passSimpleMessage();
     }
@@ -305,7 +318,7 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_SOURCE_TAG)
     public void testSourceBasicHttpAuthNull() throws IOException {
-        configure(Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, null, ExplicitAuthType.NULL);
+        configure(Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE, null, ExplicitAuthType.NULL);
 
        assertThrows(ConnectException.class, () -> this.passSimpleMessage());
     }
@@ -313,7 +326,7 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_DEST_TAG)
     public void testDestinationBasicHttpAuthNull() throws IOException {
-        configure(null, Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, ExplicitAuthType.NULL);
+        configure(null, Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE, ExplicitAuthType.NULL);
 
         assertThrows(ConnectException.class, () -> this.passSimpleMessage());
     }
@@ -321,7 +334,7 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_SOURCE_TAG)
     public void testSourceBasicHttpAuthImplicitDefault() throws IOException {
-        configure(Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, null, null);
+        configure(Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE, null, null);
 
         this.passSimpleMessage();
     }
@@ -329,9 +342,25 @@ public class TransformTest {
     @Test
     @Tag(Constants.USE_BASIC_AUTH_DEST_TAG)
     public void testDestinationBasicHttpAuthImplicitDefault() throws IOException {
-        configure(null, Constants.HTTP_AUTH_CREDENTIALS_FIXTURE, null);
+        configure(null, Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE, null);
 
         this.passSimpleMessage();
+    }
+
+    @Test
+    @Tag(Constants.USE_BASIC_AUTH_SOURCE_TAG)
+    public void testSourceBasicHttpAuthWrong() throws IOException {
+        configure(Constants.HTTP_AUTH_DEST_CREDENTIALS_FIXTURE, null, null);
+
+        assertThrows(ConnectException.class, () -> this.passSimpleMessage());
+    }
+
+    @Test
+    @Tag(Constants.USE_BASIC_AUTH_DEST_TAG)
+    public void testDestinationBasicHttpAuthWrong() throws IOException {
+        configure(null, Constants.HTTP_AUTH_SOURCE_CREDENTIALS_FIXTURE, null);
+
+        assertThrows(ConnectException.class, () -> this.passSimpleMessage());
     }
 
     @Test


### PR DESCRIPTION
HTTP Basic Authentication support in the Schema Registry Client that Registry Helper relies on uses a Singleton pattern to implement its strategies each of the three credential sources it implements a strategy for interfacing with.

Because Registry Helper uses the client for both source as well as destination access, this causes a problem if a user configured both source and destination authentication, and uses different credentials, but acquires them from the same source strategy on both ends of the line.

At runtime, registry helper first initialized the source registry client with no issues, then it proceeds to configure the destination registry client and ends up accessing the same basic HTTP Authentication helper object already in use by the source registry.  It winds up overwriting the credentials and wires the resulting client to the destination registry.  The first time the SMT attempts to read a schema using the source registry's client object, it fails due to the fact that the credentials are now for the destination registry instead of its own.

This is a little complicated to fix--we cannot modify the client to replace the existing implementation with one that is not a singleton without breaking encapsulation.  For now, this PR only includes additional test cases, with the intent to discuss an approach to fix the underlying cause and add it to the PR before it is merged.

I think the most likely approach to work is going to involve either creating a second set of identical implementations of the three basic HTTP authentication singletons.  A prefix or a suffix would be added to the three new instances and the registry client would re-map the service's lookup key (USER_INFO, URL, or SASL) to include the appropriate prefix for either the source or destination client.

I'm not sure if the shade plugin could be configured in a way to assist with this issue.  It might be able to handle a second relocation, but I don't think it could be told to add a prefix or suffix to the services' lookup keys in the process.  The former approach might require making a hand copy of the three strategies as part of this project's own codebase.  I'm open to suggestions!

Alternately, we could pursue a more heavy weight but more conservative approach and arrange for a second relocation of the entire client, perhaps by using the shade plugin in a dependency to relocate the client twice, once to a namespace intended for the source, and again to a different namespace intended for the destination.