### PR TITLE
Issue21 hide user info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,9 @@
                             <shadedPattern>${shade.prefix}.avroshaded</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
+++ b/src/main/java/cricket/jmoore/kafka/connect/transforms/SchemaRegistryTransfer.java
@@ -77,9 +77,9 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
                 .define(ConfigName.SRC_SCHEMA_REGISTRY_URL, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(), ConfigDef.Importance.HIGH, SRC_SCHEMA_REGISTRY_CONFIG_DOC)
                 .define(ConfigName.DEST_SCHEMA_REGISTRY_URL, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(), ConfigDef.Importance.HIGH, DEST_SCHEMA_REGISTRY_CONFIG_DOC)
                 .define(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, SRC_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, SRC_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DOC)
-                .define(ConfigName.SRC_USER_INFO, ConfigDef.Type.STRING, SRC_USER_INFO_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, SRC_USER_INFO_CONFIG_DOC)
+                .define(ConfigName.SRC_USER_INFO, ConfigDef.Type.PASSWORD, SRC_USER_INFO_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, SRC_USER_INFO_CONFIG_DOC)
                 .define(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE, ConfigDef.Type.STRING, DEST_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, DEST_BASIC_AUTH_CREDENTIALS_SOURCE_CONFIG_DOC)
-                .define(ConfigName.DEST_USER_INFO, ConfigDef.Type.STRING, DEST_USER_INFO_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, DEST_USER_INFO_CONFIG_DOC)
+                .define(ConfigName.DEST_USER_INFO, ConfigDef.Type.PASSWORD, DEST_USER_INFO_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, DEST_USER_INFO_CONFIG_DOC)
                 .define(ConfigName.SCHEMA_CAPACITY, ConfigDef.Type.INT, SCHEMA_CAPACITY_CONFIG_DEFAULT, ConfigDef.Importance.LOW, SCHEMA_CAPACITY_CONFIG_DOC)
                 .define(ConfigName.TRANSFER_KEYS, ConfigDef.Type.BOOLEAN, TRANSFER_KEYS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, TRANSFER_KEYS_CONFIG_DOC)
                 .define(ConfigName.INCLUDE_HEADERS, ConfigDef.Type.BOOLEAN, INCLUDE_HEADERS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM, INCLUDE_HEADERS_CONFIG_DOC)
@@ -101,14 +101,16 @@ public class SchemaRegistryTransfer<R extends ConnectRecord<R>> implements Trans
         sourceProps.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
             config.getString(ConfigName.SRC_BASIC_AUTH_CREDENTIALS_SOURCE));
         sourceProps.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG,
-            config.getString(ConfigName.SRC_USER_INFO));
+            config.getPassword(ConfigName.SRC_USER_INFO)
+                .value());
 
         List<String> destUrls = config.getList(ConfigName.DEST_SCHEMA_REGISTRY_URL);
         final Map<String, String> destProps = new HashMap<>();
         destProps.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
             config.getString(ConfigName.DEST_BASIC_AUTH_CREDENTIALS_SOURCE));
         destProps.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG,
-            config.getString(ConfigName.DEST_USER_INFO));
+            config.getPassword(ConfigName.DEST_USER_INFO)
+                .value());
 
         Integer schemaCapacity = config.getInt(ConfigName.SCHEMA_CAPACITY);
 


### PR DESCRIPTION
Not certain why this is showing #17 as also being a part of this PR.  Let me know if you'd like me to trying reverting and re-doing it to see if I can get that to go away...

The simple fix for Issue #21 is to mark two USER_INFO fields that are used with the basic HTTP Authentication Credential source is set to USER_INFO to be of type PASSWORD rather than String.  IT is a minor bit of additional compensating code to read the String from Kafka Connect's runtime "Password Value Container" and this causes Confluent to Mask the string's content when printing an adapter's configuration to the log when created and on starting the connector from a stopped state.

This does not make any special attempt to help mask the password information paired with the URL when the authentication source type is then URL and not USER_INFO.  Connect does not support hanging the data type based on the state of another property, and even if they did, there is not way
to only mask the credentials and leave the rest of the URL as-is.  Since USER_INFO uses the same encoding strategy as is used when inlining credentials in the URL, that best advice to users with URL passwords should probably be to migrate the username/password tuple from URL to USER_INFO and leverage the masking introduce here at that field instead.